### PR TITLE
support webp files with more than 99 frames

### DIFF
--- a/webp2gif
+++ b/webp2gif
@@ -33,6 +33,12 @@ done
 for i in {1..9}
 do
    if [[ -f "$i.png" ]];then
+       mv "$i.png" "00$i.png"
+   fi
+done
+for i in {10..99}
+do
+   if [[ -f "$i.png" ]];then
        mv "$i.png" "0$i.png"
    fi
 done


### PR DESCRIPTION
webp files with more than 99 frames will play weird because frames will be out of order. This patch adds support for upto 999 frames.