### PR TITLE
Support directories containing spaces

### DIFF
--- a/webp2gif
+++ b/webp2gif
@@ -5,7 +5,7 @@
 #date           :20200205
 #usage          :webp2gif input.webp output.gif
 #==============================================================================
-version=0.1
+version=0.2
 if [[ $1 == "-v" ]];then
     echo "version:$version"
     exit 0
@@ -15,14 +15,14 @@ temp_dir=$(mktemp -d)
 cd $temp_dir
 webpfile=$1
 if [[ ! -f $webpfile ]];then
-    webpfile=$cur_dir/$webpfile
+    webpfile="$cur_dir/$webpfile"
 fi
-webpfileinfo="$(webpmux -info $webpfile)"
+webpfileinfo="$(webpmux -info "$webpfile")"
 frames_num=$(echo "$webpfileinfo"|sed -n 's/Number of frames: //p')
 table_line=$(echo "$webpfileinfo"|grep -nh  "No.: width.*"|cut -d : -f 1)
 duration=0
 for i in $(seq 1 $frames_num);do
-    webpmux -get frame $i $webpfile -o "$i.webp"
+    webpmux -get frame $i "$webpfile" -o "$i.webp"
     width=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $2}')
     offset_x=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $5}')
     duration=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $7}')
@@ -37,6 +37,6 @@ rename 's/(\d+)/sprintf("%03d",$1)/e' *.png
 echo "converting all png frame file to gif..."
 duration=$((duration/10))
 convert -delay $duration -loop 0 *.png animation.gif
-mv $temp_dir/animation.gif $cur_dir/$2
+mv $temp_dir/animation.gif "$cur_dir/$2"
 rm -rf $temp_dir
 echo "finished with success!"


### PR DESCRIPTION
Added support for directory names containing spaces

For those times when I'm working with WSL Ubuntu or Debian and I find myself a Windows folder that has spaces in the directory name path. 