### PR TITLE
Add usage message and handle failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ convert animated webp to gif
 
 ### Prerequisites
 
-[webp](https://developers.google.com/speed/webp/download) && [imagemagick](https://imagemagick.org/script/download.php)
+[webp](https://developers.google.com/speed/webp/download)  
+[imagemagick](https://imagemagick.org/script/download.php)  
+[rename](http://manpages.ubuntu.com/manpages/bionic/man1/rename.ul.1.html)
 
 - macOS
 
@@ -13,11 +15,10 @@ convert animated webp to gif
    brew install rename
    ```
 
-- Ubuntu
+- Ubuntu/Debian
 
   ```
-  apt install webp
-  apt install imagemagick
+  sudo apt install webp imagemagick rename
   ```
 
 ### Usage
@@ -25,8 +26,20 @@ convert animated webp to gif
 ```shell
 wget https://git.io/webp2gif && chmod +x webp2gif
 
-./webp2gif input.webp output.gif
+./webp2gif [-v|-h] <input.webp> [output.gif]
 ```
+
+Input filename.ext is mandatory
+
+Output filename.ext is optional, if not supplied the input filename will be used, e.g. foobar.webp --> foobar.gif
+
+### Options
+
+**-v, --version**  
+&emsp;&emsp;&emsp;Display the version of the script
+
+**h, --help**  
+&emsp;&emsp;&emsp;Display a brief usage message
 
 ### Link
 Maybe you want to convert a gif to webp?

--- a/webp2gif
+++ b/webp2gif
@@ -3,24 +3,54 @@
 #description    :convert animated webp to gif
 #author         :elsonwx
 #date           :20200205
-#usage          :webp2gif input.webp output.gif
+#usage          :webp2gif input.webp [output.gif]
 #==============================================================================
-version=0.2
+version=0.3
 if [[ $1 == "-v" ]];then
     echo "version:$version"
+    exit 0
+fi
+if [[ $1 == "-h" || $1 == "--help" || -z $1 ]];then
+    cat <<EOM
+
+$(basename $0) version:$version
+
+Usage: $(basename $0) <input.webp> [output.gif]
+
+Notes: The output file name is optional.
+       If not supplied the gif extension will be used with the input filename,
+       e.g. foobar.webp --> foobar.gif
+       
+EOM
     exit 0
 fi
 cur_dir=$(pwd)
 temp_dir=$(mktemp -d)
 cd $temp_dir
 webpfile=$1
+if [[ -z $2 ]];then
+    giffile=${webpfile%%.webp}.gif
+else
+    giffile=$2
+fi
 if [[ ! -f $webpfile ]];then
     webpfile="$cur_dir/$webpfile"
+    if [[ ! -f $webpfile ]];then
+        echo "input file not found -- \"$webpfile\""
+        exit 1
+    fi    
 fi
+
+# abend on any processing errors so that we:
+#  - don't see a success message when there is a failure
+#  - set the exit code to non-zero
+set -e
+
 webpfileinfo="$(webpmux -info "$webpfile")"
 frames_num=$(echo "$webpfileinfo"|sed -n 's/Number of frames: //p')
 table_line=$(echo "$webpfileinfo"|grep -nh  "No.: width.*"|cut -d : -f 1)
 duration=0
+echo "Extracting webp frames..."
 for i in $(seq 1 $frames_num);do
     webpmux -get frame $i "$webpfile" -o "$i.webp"
     width=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $2}')
@@ -37,6 +67,6 @@ rename 's/(\d+)/sprintf("%03d",$1)/e' *.png
 echo "converting all png frame file to gif..."
 duration=$((duration/10))
 convert -delay $duration -loop 0 *.png animation.gif
-mv $temp_dir/animation.gif "$cur_dir/$2"
+mv $temp_dir/animation.gif "$cur_dir/$giffile"
 rm -rf $temp_dir
 echo "finished with success!"

--- a/webp2gif
+++ b/webp2gif
@@ -6,7 +6,7 @@
 #usage          :webp2gif input.webp [output.gif]
 #==============================================================================
 version=0.3
-if [[ $1 == "-v" ]];then
+if [[ $1 == "-v" || $1 == "--version"]];then
     echo "version:$version"
     exit 0
 fi


### PR DESCRIPTION
Some enhancements for you consideration.

- Added a usage `-h | --help` for command line usage.
- Added `--version` because some folks like to type that instead of `-v`
- Output filename is optional, if user does not supply an output name then assume that converted `foo.webp` will be output to `foo.gif`
- If input file not found, warn the user and exit with non-zero status. I had the same problem as https://github.com/elsonwx/webp2gif/issues/5 where I was in a different directory, so this will catch such cases.
- `set -e` will terminate on all errors during the webpmux processing and file renaming etc. Also related to https://github.com/elsonwx/webp2gif/issues/5 where a missing input file caused error and usage messages to fill the screen. 
- The `set -e` will also ensure that the exit status is non-zero and users won't see `finished with success!` when there is an error.
- Tested on Ubuntu Focal and Debian Buster, interestingly Debian WSL does not have `rename` by default, so I added it to the pre-requisites.
- Updated the readme accordingly.
