### PR TITLE
Remove "rename" step

### DIFF
--- a/webp2gif
+++ b/webp2gif
@@ -55,19 +55,20 @@ frames_num=$(echo "$webpfileinfo"|sed -n 's/Number of frames: //p')
 table_line=$(echo "$webpfileinfo"|grep -nh  "No.: width.*"|cut -d : -f 1)
 duration=0
 echo "Extracting webp frames..."
-for i in $(seq 1 $frames_num);do
+for i in $(seq -f "%03g" 1 $frames_num);do
     webpmux -get frame $i "$webpfile" -o "$i.webp"
-    width=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $2}')
-    offset_x=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $5}')
-    duration=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $7}')
+    
+    width=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $2}')
+    echo $width
+    offset_x=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $5}')
+    duration=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $7}')
     new_width=$((width+offset_x))
-    height=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $3}')
-    offset_y=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+i))" '{if(NR==cur_line) print $6}')
+    height=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $3}')
+    offset_y=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $6}')
     new_height=$((height+offset_y))
     dwebp "$i.webp" -o "$i.png"
     convert -gravity southeast -extent ${new_width}x${new_height} -background none "$i.png" "$i.png"
 done
-rename 's/(\d+)/sprintf("%03d",$1)/e' *.png
 echo "converting all png frame file to gif..."
 duration=$((duration/10))
 convert -delay $duration -loop 0 *.png animation.gif

--- a/webp2gif
+++ b/webp2gif
@@ -59,7 +59,6 @@ for i in $(seq -f "%03g" 1 $frames_num);do
     webpmux -get frame $i "$webpfile" -o "$i.webp"
     
     width=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $2}')
-    echo $width
     offset_x=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $5}')
     duration=$(echo "$webpfileinfo"|awk -v cur_line="$((table_line+10#$i))" '{if(NR==cur_line) print $7}')
     new_width=$((width+offset_x))


### PR DESCRIPTION
The for loop now will generate the numbers as 001 002 003 ...etc so no need for renaming the files later

Also the "10#" in "10#$i" is for telling the shell that it is a decimal number and not octal, since by default it treat any number that starts with 0 as octal

Closes issue: https://github.com/elsonwx/webp2gif/issues/10