### PR TITLE
Update webp2gif

### DIFF
--- a/webp2gif
+++ b/webp2gif
@@ -70,7 +70,7 @@ for i in $(seq -f "%03g" 1 $frames_num);do
 done
 echo "converting all png frame file to gif..."
 duration=$((duration/10))
-convert -delay $duration -loop 0 *.png animation.gif
+convert -delay $duration -loop 0 -alpha set -dispose previous *.png animation.gif
 mv $temp_dir/animation.gif "$cur_dir/$giffile"
 rm -rf $temp_dir
 echo "finished with success!"


### PR DESCRIPTION
Fixed occasional strange behavior with transparency causing some GIFs to retain previous frame's content. 

Before:
![before](https://user-images.githubusercontent.com/2394282/126550159-a73a6cd5-93db-47af-bbbe-c4ab260bcf95.gif)


After:
![after](https://user-images.githubusercontent.com/2394282/126550206-9f3054dd-8a38-4750-a350-0d07453861f7.gif)
